### PR TITLE
Add length checks

### DIFF
--- a/clientHello.go
+++ b/clientHello.go
@@ -99,7 +99,7 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 	ch.CipherSuiteLen = uint16(hs[0])<<8 | uint16(hs[1])
 
 	numCiphers := ch.CipherSuiteLen / 2
-	if len(hs) < int(ch.CipherSuiteLen) {
+	if len(hs) < int(ch.CipherSuiteLen) + 3 {
 		return ErrHandshakeBadLength
 	}
 

--- a/clientHello.go
+++ b/clientHello.go
@@ -187,6 +187,9 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 				default:
 					// Unknown Name Type
 				}
+				if len(data) < nameLen {
+					return ErrHandshakeExtBadLength
+				}
 				data = data[nameLen:]
 			}
 		case ExtSignatureAlgs:

--- a/clientHello.go
+++ b/clientHello.go
@@ -261,6 +261,9 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 			for len(data) > 0 {
 				stringLen := int(data[0])
 				data = data[1:]
+				if len(data) < stringLen {
+					return ErrHandshakeExtBadLength
+				}
 				ch.ALPNs = append(ch.ALPNs, string(data[:stringLen]))
 				data = data[stringLen:]
 			}


### PR DESCRIPTION
Hi.

This PR adds length checks to fix these panics we've seen on malformed input:

```
panic: runtime error: index out of range [10] with length 10
goroutine 26 [running]:
github.com/dreadl0ck/tlsx.(*ClientHello).Unmarshal(0xc00b1437a0, {0xc00a4e0576?, 0x40bd92?, 0xc0003001e0?})
#011/go/pkg/mod/github.com/coreyralph/tlsx@v0.0.0-20240208042857-bff7a2fb8226/clientHello.go:108 +0x102d
github.com/dreadl0ck/tlsx.GetClientHello({0xaa0378?, 0xc00b2d1b80?})
#011/go/pkg/mod/github.com/coreyralph/tlsx@v0.0.0-20240208042857-bff7a2fb8226/utils.go:45 +0x6d
```

```
panic: runtime error: slice bounds out of range [6912:1]
goroutine 12 [running]:
github.com/dreadl0ck/tlsx.(*ClientHello).Unmarshal(0xc0019758c0, {0xc001b6c936?, 0x40bd92?, 0xc0000439e0?})
#011/go/pkg/mod/github.com/coreyralph/tlsx@v0.0.0-20240208042857-bff7a2fb8226/clientHello.go:190 +0xfd8
github.com/dreadl0ck/tlsx.GetClientHello({0xaa0378?, 0xc002d16b00?})
#011/go/pkg/mod/github.com/coreyralph/tlsx@v0.0.0-20240208042857-bff7a2fb8226/utils.go:45 +0x6d
```

```
panic: runtime error: slice bounds out of range [104:7]
goroutine 54 [running]:
github.com/dreadl0ck/tlsx.(*ClientHello).Unmarshal(0xc0007597a0, {0xc0008722c2?, 0x40bd92?, 0xc0003224e0?})
#011/go/pkg/mod/github.com/dreadl0ck/tlsx@v1.0.0/clientHello.go:274 +0xde5
github.com/dreadl0ck/tlsx.GetClientHello({0xaa0218?, 0xc000353600?})
#011/go/pkg/mod/github.com/dreadl0ck/tlsx@v1.0.0/utils.go:45 +0x6d
```