### PR TITLE
ClientHelloBasic: add len check on ExtServerName in Unmarshal

### DIFF
--- a/clientHello.go
+++ b/clientHello.go
@@ -442,6 +442,10 @@ func (ch *ClientHelloBasic) Unmarshal(payload []byte) error {
 				default:
 					// Unknown Name Type
 				}
+				if len(data) < nameLen {
+					// Malformed nameLen for ServerName
+					return ErrHandshakeExtBadLength
+				}
 				data = data[nameLen:]
 			}
 		case ExtSupportedGroups:


### PR DESCRIPTION
Hello,

While fingerprinting some clientHellos, I stumbled on the bug this commit fixes.

The fix from 0660b600 has only addressed the issue for the function Unmarshal from ClientHello. This commit addresses the same problem for ClientHelloBasic, which is used for ja3 fingerprinting.

I would also suggest bumping the version of tlsx in ja3's `go.mod` (otherwise it would defeat the purpose of this change).

All the best,
Damien.