### PR TITLE
ClientHello: various fixes following a code review

### DIFF
--- a/clientHello.go
+++ b/clientHello.go
@@ -181,14 +181,15 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 				nameLen := int(data[1])<<8 | int(data[2])
 				data = data[3:]
 
-				switch nameType {
-				case SNINameTypeDNS:
-					ch.SNI = string(data)
-				default:
-					// Unknown Name Type
-				}
 				if len(data) < nameLen {
 					return ErrHandshakeExtBadLength
+				}
+
+				switch nameType {
+				case SNINameTypeDNS:
+					ch.SNI = string(data[:nameLen])
+				default:
+					// Unknown Name Type
 				}
 				data = data[nameLen:]
 			}
@@ -435,10 +436,15 @@ func (ch *ClientHelloBasic) Unmarshal(payload []byte) error {
 
 				nameLen := int(data[1])<<8 | int(data[2])
 
+				if len(data) < nameLen {
+					// Malformed nameLen for ServerName
+					return ErrHandshakeExtBadLength
+				}
+
 				data = data[3:]
 				switch nameType {
 				case SNINameTypeDNS:
-					ch.SNI = string(data)
+					ch.SNI = string(data[:nameLen])
 				default:
 					// Unknown Name Type
 				}

--- a/clientHello.go
+++ b/clientHello.go
@@ -162,7 +162,7 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 			if len(data) < 2 {
 				return ErrHandshakeExtBadLength
 			}
-			sniLen := int(data[0])<<8 | int(data[0])
+			sniLen := int(data[0])<<8 | int(data[1])
 
 			data = data[2:]
 
@@ -416,7 +416,7 @@ func (ch *ClientHelloBasic) Unmarshal(payload []byte) error {
 			if len(data) < 2 {
 				return ErrHandshakeExtBadLength
 			}
-			sniLen := int(data[0])<<8 | int(data[0])
+			sniLen := int(data[0])<<8 | int(data[1])
 
 			data = data[2:]
 

--- a/clientHello.go
+++ b/clientHello.go
@@ -99,7 +99,7 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 	ch.CipherSuiteLen = uint16(hs[0])<<8 | uint16(hs[1])
 
 	numCiphers := ch.CipherSuiteLen / 2
-	if len(hs) < int(ch.CipherSuiteLen) + 3 {
+	if len(hs) < int(ch.CipherSuiteLen)+2 {
 		return ErrHandshakeBadLength
 	}
 
@@ -133,7 +133,7 @@ func (ch *ClientHello) Unmarshal(payload []byte) error {
 	// Extensions
 	ch.ExtensionLen = uint16(hs[0])<<8 | uint16(hs[1])
 
-	if len(hs) < int(ch.ExtensionLen) {
+	if len(hs) < int(ch.ExtensionLen)+2 {
 		return ErrHandshakeExtBadLength
 	}
 
@@ -361,7 +361,7 @@ func (ch *ClientHelloBasic) Unmarshal(payload []byte) error {
 	ch.CipherSuiteLen = uint16(hs[0])<<8 | uint16(hs[1])
 
 	numCiphers := ch.CipherSuiteLen / 2
-	if len(hs) < int(ch.CipherSuiteLen) {
+	if len(hs) < int(ch.CipherSuiteLen)+2 {
 		return ErrHandshakeBadLength
 	}
 
@@ -390,7 +390,7 @@ func (ch *ClientHelloBasic) Unmarshal(payload []byte) error {
 
 	// Extensions
 	ch.ExtensionLen = uint16(hs[0])<<8 | uint16(hs[1])
-	if len(hs) < int(ch.ExtensionLen) {
+	if len(hs) < int(ch.ExtensionLen)+2 {
 		return ErrHandshakeExtBadLength
 	}
 


### PR DESCRIPTION
Hello, this pull request is a bit more impactful than https://github.com/dreadl0ck/tlsx/pull/2, but it addresses a few more issues found in the code that surfaced upon closer inspection (including the one from the aforementioned PR, as it reworks that part as well).

The issues found are:
- one tight length check (wanted one too many bytes)
- a few loose length checks (needed two more bytes)
- one length parser was using the same byte for MSD and LSD instead of the two adjacent bytes warranted
- one length check was missing (this is the issue discussed in https://github.com/dreadl0ck/tlsx/pull/2)

If the changes proposed here are deemed fine, I suggest closing https://github.com/dreadl0ck/tlsx/pull/2 and only merging this one. I made both PRs in case this one raised concerns and required further discussions, as the missing length check causes crashes that would be nice to be fixed asap. :)

I would like to remind that the changes in `ClientHelloBasic` are only really meaningful if the version of tlsx required by the ja3 module is bumped afterwards.

All the best,
Damien.